### PR TITLE
resource resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,10 +2826,12 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 name = "i18n"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "bevy",
  "fluent-templates",
  "sys-locale",
  "unic-langid",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "rfd",
  "sysinfo",
  "ui",
+ "utils",
  "winresource",
 ]
 

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -40,6 +40,7 @@ dev = [
   "assets/dev",
   "i18n/dev",
   "io/dev",
+  "utils/dev",
   "ui/dev",
   "config/dev",
   "logging/dev",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 assets = { workspace = true }
 i18n = { workspace = true }
 io = { workspace = true }
+utils = { workspace = true }
 ui = { workspace = true }
 config = { workspace = true }
 logging = { workspace = true }

--- a/crates/editor/src/main.rs
+++ b/crates/editor/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> AppExit {
             DefaultPlugins
                 .set(log_plugin(&config.logging))
                 .set(bevy::asset::AssetPlugin {
-                    file_path: resource_path.join("assets").to_string_lossy().to_string(),
+                    file_path: utils::to_string(&resource_path.join("assets")),
                     ..default()
                 }),
             I18nPlugin::new(&config.language),

--- a/crates/editor/src/main.rs
+++ b/crates/editor/src/main.rs
@@ -23,9 +23,15 @@ fn main() -> AppExit {
         Err(err) => panic!("Failed to load configuration: {err:?}"),
     };
 
+    let resource_path = utils::resource_path().expect("Failed to get resource path");
     App::new()
         .add_plugins((
-            DefaultPlugins.set(log_plugin(&config.logging)),
+            DefaultPlugins
+                .set(log_plugin(&config.logging))
+                .set(bevy::asset::AssetPlugin {
+                    file_path: resource_path.join("assets").to_string_lossy().to_string(),
+                    ..default()
+                }),
             I18nPlugin::new(&config.language),
             IOPlugin,
             UIPlugin,

--- a/crates/i18n/Cargo.toml
+++ b/crates/i18n/Cargo.toml
@@ -11,6 +11,8 @@ authors.workspace = true
 
 [dependencies]
 bevy = { workspace = true }
+utils = { workspace = true }
+anyhow = { workspace = true }
 fluent-templates = { version = "0.13.0", features = ["walkdir"] }
 sys-locale = "0.3.2"
 unic-langid = "0.9.6"
@@ -20,5 +22,7 @@ workspace = true
 
 [features]
 default = []
-dev = []
+dev = [
+    "utils/dev"
+]
 

--- a/crates/ui/src/plugin.rs
+++ b/crates/ui/src/plugin.rs
@@ -6,7 +6,8 @@ use crate::layout::render_editor_layout;
 use crate::notifications::Notifications;
 use crate::state::UiState;
 use bevy::app::App;
-use bevy::prelude::{Plugin, PostUpdate, Startup};
+use bevy::asset::AssetServer;
+use bevy::prelude::{Commands, Plugin, PostUpdate, ResMut, Sprite, Startup};
 use bevy_egui::{EguiPlugin, EguiPrimaryContextPass};
 
 /// A [Bevy](https://bevyengine.org/) plugin that adds UI to the app it's added to.
@@ -25,5 +26,12 @@ impl Plugin for UIPlugin {
         // editor docking layout
         app.insert_resource(UiState::default())
             .add_systems(EguiPrimaryContextPass, render_editor_layout);
+
+        // for testing purposes.
+        app.add_systems(Startup, spawn_demo_asset);
     }
+}
+
+fn spawn_demo_asset(mut commands: Commands, asset_server: ResMut<AssetServer>) {
+    commands.spawn(Sprite::from_image(asset_server.load("logo.png")));
 }

--- a/crates/ui/src/plugin.rs
+++ b/crates/ui/src/plugin.rs
@@ -32,6 +32,8 @@ impl Plugin for UIPlugin {
     }
 }
 
+/// Test system that spawns an image, used to validate resource loading.
+#[utils::bevy_system]
 fn spawn_demo_asset(mut commands: Commands, asset_server: ResMut<AssetServer>) {
     commands.spawn(Sprite::from_image(asset_server.load("logo.png")));
 }

--- a/crates/utils/src/pathbuf.rs
+++ b/crates/utils/src/pathbuf.rs
@@ -10,3 +10,12 @@ use std::path::Path;
 pub fn file_name(path: &Path) -> Option<String> {
     Some(path.file_name()?.to_string_lossy().to_string())
 }
+
+/// Simple shorthand for `path.to_string_lossy().to_string()`
+///
+/// This method is lossy in case of invalid UTF-8 characters, see [`OsStr::to_string_lossy`]
+#[inline]
+#[must_use]
+pub fn to_string(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}


### PR DESCRIPTION
As described in #34, resource loading (resources being the bundled assets and other required files) should be done in a platform specific way (and even then, differently in development).

this PR adds a `resource_path` method that handles precisely such a case