### PR TITLE
CI linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,10 +59,34 @@ jobs:
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+
+  lint:
+    name: Lint code on ${{ matrix.label }}
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - label: Linux
+            platform: ubuntu-latest
+            profile: fast
+          - label: Windows
+            platform: windows-latest
+            profile: dev
+          - label: OSX
+            platform: macos-latest
+            profile: fast
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Run cargo check
-        run: cargo check --locked --all-features --profile=fast
+        run: cargo check --locked --all-features --profile=${{ matrix.profile }}
       - name: Run cargo clippy
-        run: cargo clippy --locked --all-features --profile=fast
+        run: cargo clippy --locked --all-targets --all-features --profile=${{ matrix.profile }} -- -D warnings
 
   doc:
     name: Build documentation

--- a/crates/assets/src/library.rs
+++ b/crates/assets/src/library.rs
@@ -328,7 +328,7 @@ impl AssetLibrary {
         let query = query.as_ref();
 
         let _ = trace_span!("search", query = query).entered();
-        for (_id, asset_pack) in self.loaded_packs.iter() {
+        for asset_pack in self.loaded_packs.values() {
             let mut result = asset_pack.search(query, max_amount)?;
             results.append(&mut result);
         }

--- a/crates/assets/src/packs/index.rs
+++ b/crates/assets/src/packs/index.rs
@@ -172,6 +172,7 @@ impl AssetPackIndex {
             .delete_all_documents()
             .map_err(|error| AssetPackIndexError::Index(index_root.to_path_buf(), error))?;
 
+        #[allow(unused_variables, reason = "Pending implementation of #79")]
         let mut current: u64 = 0;
         #[allow(
             clippy::explicit_counter_loop,
@@ -432,6 +433,7 @@ impl AssetPackSearchResult {
     }
 
     /// Attempt to resolve the `name` field from the result.
+    #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.document
             .get_first(self.name)
@@ -441,28 +443,30 @@ impl AssetPackSearchResult {
     /// Resolves the `categories` field from the result.
     ///
     /// If no values are set an empty list is returned.
+    #[must_use]
     pub fn categories(&self) -> Vec<&str> {
         self.document
             .get_all(self.categories)
-            .map(|value| value.as_str())
-            .flatten()
+            .filter_map(|value| value.as_str())
             .collect::<Vec<_>>()
     }
 
     /// Attempt to resolve the `path` field from the result.
+    #[must_use]
     pub fn path(&self) -> Option<PathBuf> {
         self.document
             .get_first(self.path)
             .and_then(|value| value.as_str())
-            .map(|value| PathBuf::from(value))
+            .map(PathBuf::from)
     }
 
     /// Attempt to resolve the `thumbnail` field from the result.
+    #[must_use]
     pub fn thumbnail(&self) -> Option<PathBuf> {
         self.document
             .get_first(self.thumbnail)
             .and_then(|value| value.as_str())
-            .map(|value| PathBuf::from(value))
+            .map(PathBuf::from)
     }
 }
 
@@ -471,21 +475,19 @@ impl Display for AssetPackSearchResult {
         let name = self.name().unwrap_or("<no value>");
         let path = self
             .path()
-            .map(|path| utils::to_string(&path))
-            .unwrap_or(String::from("<no value>"));
+            .map_or(String::from("<no value>"), |path| utils::to_string(&path));
         let categories = self.categories();
         let thumbnail = self
             .path()
-            .map(|path| utils::to_string(&path))
-            .unwrap_or(String::from("<no value>"));
+            .map_or(String::from("<no value>"), |path| utils::to_string(&path));
 
-        writeln!(f, "name: {}", name)?;
+        writeln!(f, "name: {name}")?;
         writeln!(f, "categories:")?;
         for category in categories {
-            writeln!(f, "- {}", category)?;
+            writeln!(f, "- {category}")?;
         }
-        writeln!(f, "path: {}", path)?;
-        writeln!(f, "thumbnail: {}", thumbnail)?;
+        writeln!(f, "path: {path}")?;
+        writeln!(f, "thumbnail: {thumbnail}")?;
 
         Ok(())
     }

--- a/crates/cli/src/commands/assets.rs
+++ b/crates/cli/src/commands/assets.rs
@@ -61,9 +61,10 @@ pub enum Commands {
         #[arg(long)]
         thumbnails: bool,
     },
+    /// Executes a query against the asset library.
     Query {
         /// The query to execute against the library, for the syntax see
-        /// https://docs.rs/tantivy/0.24.2/tantivy/query/struct.QueryParser.html
+        /// <https://docs.rs/tantivy/0.24.2/tantivy/query/struct.QueryParser.html>
         query: String,
 
         /// The (maximum) number of results to return for this query.


### PR DESCRIPTION
fixes how linting is currently handled in CI

fixes #89 and #90 as well as ensuring that linting is ran for all platforms.
This is because we have platform dependent code (mostly in `utils`) that needs linting on all platforms for full coverage.