### PR TITLE
chore: bump MSRV to 1.89.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 profile = "minimal"
 components = [ "clippy", "rustfmt", "rust-analyzer" ]


### PR DESCRIPTION
Update MSRV from `1.88.0` to `1.89.0`