### PR TITLE
feat: allow specifying config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ version = "0.0.1"
 dependencies = [
  "assets",
  "bevy",
+ "clap",
  "config",
  "i18n",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ semver = { version = "1.0.26", features = ["serde"] }
 tempfile = { version = "3.20.0" }
 native-dialog = { version = "0.9.0", default-features = false, features = ["windows_dpi_awareness", "windows_visual_styles"] }
 crossbeam-channel = "0.5.15"
+clap = { version = "4.5.45", features = ["derive"] }
 
 # Workspace packages
 assets = { path = "crates/assets" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ bevy = { workspace = true }
 utils = { workspace = true }
 assets = { workspace = true }
 logging = { workspace = true, features = ["console"] }
-clap = { version = "4.5.45", features = ["derive"] }
+clap = { workspace = true }
 clap-verbosity-flag = { version = "3.0.3", default-features = false, features = ["tracing"] }
 anyhow = { workspace = true }
 

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -23,6 +23,7 @@ config = { workspace = true }
 logging = { workspace = true }
 bevy = { workspace = true }
 native-dialog = { workspace = true }
+clap = { workspace = true }
 sysinfo = { version = "0.37.0", default-features = false, features = ["system"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/crates/editor/src/main.rs
+++ b/crates/editor/src/main.rs
@@ -3,9 +3,9 @@
 
 mod panic;
 
-use std::path::PathBuf;
 use assets::AssetPlugin;
 use clap::Parser;
+use std::path::PathBuf;
 
 use bevy::prelude::*;
 use config::Configuration;

--- a/crates/editor/src/main.rs
+++ b/crates/editor/src/main.rs
@@ -3,7 +3,9 @@
 
 mod panic;
 
+use std::path::PathBuf;
 use assets::AssetPlugin;
+use clap::Parser;
 
 use bevy::prelude::*;
 use config::Configuration;
@@ -12,6 +14,14 @@ use io::IOPlugin;
 use logging::log_plugin;
 use ui::UIPlugin;
 
+/// Arguments for running the editor.
+#[derive(Debug, Parser)]
+struct Args {
+    /// Optionally, specify a configuration file to use.
+    #[clap(short, long)]
+    config_file: Option<PathBuf>,
+}
+
 /// Main entry point for the editor.
 ///
 /// # Panics
@@ -19,7 +29,9 @@ use ui::UIPlugin;
 /// circumstances for when Bevy panics can be found in Bevy's documentation.
 fn main() -> AppExit {
     panic::register_panic_handler();
-    let config = match Configuration::load() {
+
+    let args = Args::parse();
+    let config = match Configuration::load(args.config_file) {
         Ok(cfg) => cfg,
         Err(err) => panic!("Failed to load configuration: {err:?}"),
     };


### PR DESCRIPTION
Allow command line argument for specifying config path.

- move `clap` to workspace `Cargo.toml` to lock version across crates
- add `file` field on `Configuration` to allow specifying where to load/save configuration files
- update `Configuration::save` and `Configuration::load` to use new field
- update `editor` binary to accept command line argument and pass it to `Configuration::load`