### PR TITLE
Embed `path` in `Project` component

### DIFF
--- a/crates/data/src/element.rs
+++ b/crates/data/src/element.rs
@@ -23,6 +23,7 @@ use bevy::prelude::Visibility;
 /// # use data::Level;
 /// # use data::Layer;
 /// # use data::Element;
+/// # use std::path::PathBuf;
 /// #
 /// # fn main() {
 /// #   App::new()
@@ -31,15 +32,16 @@ use bevy::prelude::Visibility;
 /// # }
 /// #
 /// # fn spawn_project(mut commands: Commands) {
+/// #   let output = PathBuf::new();
 ///     commands.spawn((
-///         Project::new("Roadside Inn"),
+///         Project::new(output, "Roadside Inn"),
 ///         children![(
 ///             Level::new("Ground Floor"),
 ///             children![(
 ///                 Layer::new("Walls", Transform::IDENTITY),
-///                 children![(
+///                 children![
 ///                     Element::new_object(String::from("<hash-of-resolvable-asset")),
-///                 )]
+///                 ]
 ///             )]
 ///         )]
 ///     ));

--- a/crates/data/src/layer.rs
+++ b/crates/data/src/layer.rs
@@ -25,6 +25,7 @@ impl Layer {
     /// # use data::Project;
     /// # use data::Level;
     /// # use data::Layer;
+    /// # use std::path::PathBuf;
     /// #
     /// # fn main() {
     /// #   App::new()
@@ -33,8 +34,9 @@ impl Layer {
     /// # }
     /// #
     /// # fn spawn_project(mut commands: Commands) {
+    /// #   let output = PathBuf::new();
     ///     commands.spawn((
-    ///         Project::new("Roadside Inn"),
+    ///         Project::new(output, "Roadside Inn"),
     ///         children![
     ///             Level::new("Ground Floor"),
     ///             children![

--- a/crates/data/src/level.rs
+++ b/crates/data/src/level.rs
@@ -26,6 +26,7 @@ impl Level {
     /// # use bevy::prelude::*;
     /// # use data::Project;
     /// # use data::Level;
+    /// # use std::path::PathBuf;
     /// #
     /// # fn main() {
     /// #   App::new()
@@ -34,8 +35,9 @@ impl Level {
     /// # }
     /// #
     /// # fn spawn_project(mut commands: Commands) {
+    /// #   let output = PathBuf::new();
     ///     commands.spawn((
-    ///         Project::new("Roadside Inn"),
+    ///         Project::new(output, "Roadside Inn"),
     ///         children![
     ///             Level::new("Ground Floor")
     ///         ]

--- a/crates/data/src/project.rs
+++ b/crates/data/src/project.rs
@@ -1,6 +1,7 @@
 //! Defines the [`Project`] struct and it's implementations.
 use bevy::prelude::{Bundle, Component, Name, Transform, Visibility};
 use std::borrow::Cow;
+use std::path::PathBuf;
 
 /// Top level component in the hierarchy used by `DungeonRS` to identify components that relate to the
 /// map the user is editing. In short, only components under this [`Project`] component will be considered
@@ -14,7 +15,12 @@ use std::borrow::Cow;
 #[derive(Component)]
 #[component(immutable)]
 #[require(Transform::from_xyz(0.0, 0.0, 0.0), Visibility::default())]
-pub struct Project;
+pub struct Project {
+    /// The path to the file that this project is associated with.
+    ///
+    /// Note that this file may or may not exist (for example if the project was created but not saved).
+    pub file: PathBuf,
+}
 
 impl Project {
     /// Generates a new [`Bundle`] with a project to indicate the start of a hierarchy under which
@@ -29,6 +35,7 @@ impl Project {
     /// Here's how to spawn a simple `Project` named "Roadside Inn"
     ///
     /// ```
+    /// # use std::path::PathBuf;
     /// # use bevy::prelude::*;
     /// # use data::Project;
     /// #
@@ -39,12 +46,13 @@ impl Project {
     /// # }
     /// #
     /// # fn spawn_project(mut commands: Commands) {
-    ///     commands.spawn(Project::new("Roadside Inn"));
+    /// #   let output = PathBuf::new();
+    ///     commands.spawn(Project::new(output, "Roadside Inn"));
     /// # }
     /// ```
     #[allow(clippy::new_ret_no_self)]
     #[must_use = "Project won't be added to the world unless spawned"]
-    pub fn new(name: impl Into<Cow<'static, str>>) -> impl Bundle {
-        (Name::new(name), Project {})
+    pub fn new(file: PathBuf, name: impl Into<Cow<'static, str>>) -> impl Bundle {
+        (Name::new(name), Project { file })
     }
 }

--- a/crates/data/src/query.rs
+++ b/crates/data/src/query.rs
@@ -16,13 +16,13 @@ use bevy::prelude::{Children, Entity, Name, Query, Transform, Visibility};
 #[derive(QueryData)]
 pub struct ProjectQuery {
     /// The entity ID of the project
-    entity: Entity,
+    pub entity: Entity,
     /// The human-readable name of the project
     pub name: &'static Name,
     /// Child entities (levels) belonging to this project
-    children: &'static Children,
+    pub children: &'static Children,
     /// The project-specific component data
-    project: &'static Project,
+    pub project: &'static Project,
 }
 
 /// A query for level entities, containing all necessary components to work with levels
@@ -39,7 +39,7 @@ pub struct LevelQuery {
     /// The human-readable name of the level
     pub name: &'static Name,
     /// Child entities (layers) belonging to this level
-    children: &'static Children,
+    pub children: &'static Children,
     /// Whether this level is currently visible/enabled
     visibility: &'static Visibility,
 }
@@ -60,7 +60,7 @@ pub struct LayerQuery {
     /// The spatial transformation (position, rotation, scale) of the layer
     pub transform: &'static Transform,
     /// Child entities (elements) belonging to this layer
-    children: &'static Children,
+    pub children: &'static Children,
     /// Whether this layer is currently visible/enabled
     visibility: &'static Visibility,
 }
@@ -75,7 +75,7 @@ pub struct ElementQuery {
     /// The entity ID of the element
     entity: Entity,
     /// The element-specific component data
-    element: &'static Element,
+    pub element: &'static Element,
     /// The human-readable name of the element
     pub name: &'static Name,
     /// The spatial transformation (position, rotation, scale) of the element

--- a/crates/data/src/query.rs
+++ b/crates/data/src/query.rs
@@ -245,13 +245,16 @@ mod tests {
     use super::*;
     use bevy::ecs::system::SystemState;
     use bevy::prelude::{Commands, World};
+    use std::path::PathBuf;
 
     fn create_test_hierarchy(world: &mut World) -> (Entity, Entity, Entity, Entity) {
         let mut system_state: SystemState<Commands> = SystemState::new(world);
         let mut commands = system_state.get_mut(world);
 
         // Create project
-        let project_entity = commands.spawn(Project::new("Test Project")).id();
+        let project_entity = commands
+            .spawn(Project::new(PathBuf::new(), "Test Project"))
+            .id();
 
         // Create level
         let level_entity = commands
@@ -431,7 +434,9 @@ mod tests {
         let mut commands = system_state.get_mut(&mut world);
 
         // Create a project with multiple levels
-        let project_entity = commands.spawn(Project::new("Multi-Level Project")).id();
+        let project_entity = commands
+            .spawn(Project::new(PathBuf::new(), "Multi-Level Project"))
+            .id();
         let level1_entity = commands
             .spawn((Level::new("Level 1"), Children::default()))
             .id();

--- a/crates/io/src/document.rs
+++ b/crates/io/src/document.rs
@@ -180,12 +180,13 @@ mod tests {
     use bevy::ecs::system::SystemState;
     use bevy::prelude::*;
     use data::{Layer, Level, Project};
+    use std::path::PathBuf;
 
     #[test]
     pub fn document_new() -> anyhow::Result<()> {
         let mut world = World::default();
         world.spawn((
-            Project::new("Example Project"),
+            Project::new(PathBuf::new(), "Example Project"),
             children![(
                 Level::new("First Level"),
                 children![(

--- a/crates/io/src/document.rs
+++ b/crates/io/src/document.rs
@@ -2,18 +2,17 @@
 //! from storage. This module is intentionally not made public, since these structs have no use
 //! beyond persistence and should not be used outside this scope.
 
+use bevy::ecs::{relationship::RelationshipTarget, system::Query};
 use bevy::prelude::{Quat, Vec3};
-use bevy::{
-    ecs::{relationship::RelationshipTarget, system::Query},
-    prelude::{Children, Name},
-    transform::components::Transform,
+use data::{
+    Element, ElementQuery, ElementQueryItem, LayerQuery, LayerQueryItem, LevelQuery,
+    LevelQueryItem, ProjectQueryItem,
 };
-use data::{Element, Layer, Level};
 use serialization::{Deserialize, Serialize};
 
 /// A [`Document`] represents a [`data::Project`] (and it's children) that is written to or read from storage.
 ///
-/// It's an intentionally simplified representation of the ECS datastructure optimised for serialisation.
+/// It's an intentionally simplified representation of the ECS data structure optimised for serialisation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Document {
     /// See `name` in [`data::Project::new`].
@@ -25,7 +24,7 @@ pub struct Document {
 /// A [`DocumentLevel`] represents a [`data::Level`] (and it's children) that is written to or read
 /// from storage.
 ///
-/// It's an intentionally simplified representation of the ECS datastructure optimised for serialisation.
+/// It's an intentionally simplified representation of the ECS data structure optimised for serialisation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DocumentLevel {
     /// See `name` in [`data::Level::new`].
@@ -37,7 +36,7 @@ pub struct DocumentLevel {
 /// A [`DocumentLayer`] represents a [`data::Layer`] (and it's children) that is written to or read
 /// from storage.
 ///
-/// It's an intentionally simplified representation of the ECS datastructure optimised for serialisation.
+/// It's an intentionally simplified representation of the ECS data structure optimised for serialisation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DocumentLayer {
     /// See `name` in [`data::Layer::new`].
@@ -72,27 +71,27 @@ impl Document {
     /// Generate a new [`Document`] and it's related children based on the current state (fetched
     /// through the `level_query` and `layer_query` queries).
     ///
-    /// The `value` parameter is the result of a [`bevy::prelude::Query`] to fetch the relevant
+    /// The `value` parameter is the result of a [`data::ProjectQuery`] to fetch the relevant
     /// data for the [`data::Project`] component.
     ///
     /// See [`DocumentLevel::new`] for `level_query`.
     ///
     /// See [`DocumentLayer::new`] for `layer_query`.
     pub fn new(
-        value: (&Name, &Children),
-        level_query: Query<(&Level, &Name, &Children)>,
-        layer_query: Query<(&Layer, &Name, &Transform, &Children)>,
-        object_query: Query<(&Element, &Name, &Transform)>,
+        value: &ProjectQueryItem,
+        level_query: Query<LevelQuery>,
+        layer_query: Query<LayerQuery>,
+        object_query: Query<ElementQuery>,
     ) -> Self {
         let levels: Vec<DocumentLevel> = value
-            .1
+            .children
             .iter()
             .flat_map(|pc| level_query.get(pc))
-            .map(|lvl| DocumentLevel::new(lvl, layer_query, object_query))
+            .map(|lvl| DocumentLevel::new(&lvl, layer_query, object_query))
             .collect();
 
         Self {
-            name: value.0.to_string(),
+            name: value.name.to_string(),
             levels,
         }
     }
@@ -102,25 +101,25 @@ impl DocumentLevel {
     /// Generate a new [`DocumentLevel`] and it's related children based on the current state
     /// (fetched through the `layer_query`).
     ///
-    /// The `value` parameter is the result of a [`bevy::prelude::Query`] to fetch the relevant
+    /// The `value` parameter is the result of a [`data::LevelQuery`] to fetch the relevant
     /// data for the [`data::Level`], and is usually passed from [`Document::new`].
     ///
     /// See [`Document::new`] for how this is called.
     ///
     /// See [`DocumentLayer::new`] for `layer_query`.
     pub fn new(
-        value: (&Level, &Name, &Children),
-        layer_query: Query<(&Layer, &Name, &Transform, &Children)>,
-        object_query: Query<(&Element, &Name, &Transform)>,
+        value: &LevelQueryItem,
+        layer_query: Query<LayerQuery>,
+        object_query: Query<ElementQuery>,
     ) -> Self {
         let layers = value
-            .2
+            .children
             .iter()
             .flat_map(|c| layer_query.get(c))
-            .map(|value| DocumentLayer::new(value, object_query))
+            .map(|value| DocumentLayer::new(&value, object_query))
             .collect();
         Self {
-            name: value.1.to_string(),
+            name: value.name.to_string(),
             layers,
         }
     }
@@ -132,20 +131,17 @@ impl DocumentLayer {
     /// TODO: fetch child `items`.
     ///
     /// See [`DocumentLevel::new`] for how this is called.
-    pub fn new(
-        value: (&Layer, &Name, &Transform, &Children),
-        object_query: Query<(&Element, &Name, &Transform)>,
-    ) -> Self {
+    pub fn new(value: &LayerQueryItem, object_query: Query<ElementQuery>) -> Self {
         let items: Vec<DocumentItem> = value
-            .3
+            .children
             .iter()
             .flat_map(|c| object_query.get(c))
-            .map(DocumentItem::new)
+            .map(|item| DocumentItem::new(&item))
             .collect();
 
         Self {
-            name: value.1.to_string(),
-            order: value.2.translation.z,
+            name: value.name.to_string(),
+            order: value.transform.translation.z,
             items,
         }
     }
@@ -156,13 +152,13 @@ impl DocumentItem {
     ///
     /// # Panics
     /// This method can panic if the [`data::Element`] is an unsupported type.
-    pub fn new(value: (&Element, &Name, &Transform)) -> Self {
-        match value.0 {
+    pub fn new(value: &ElementQueryItem) -> Self {
+        match value.element {
             Element::Object(object) => DocumentItem::Object {
                 id: object.clone(),
-                translation: value.2.translation,
-                rotation: value.2.rotation,
-                scale: value.2.scale,
+                translation: value.transform.translation,
+                rotation: value.transform.rotation,
+                scale: value.transform.scale,
             },
             _ => panic!("DocumentItem::new called with unsupported Element type"),
         }
@@ -179,7 +175,7 @@ mod tests {
     use super::*;
     use bevy::ecs::system::SystemState;
     use bevy::prelude::*;
-    use data::{Layer, Level, Project};
+    use data::{Layer, Level, Project, ProjectQuery};
     use std::path::PathBuf;
 
     #[test]
@@ -201,15 +197,15 @@ mod tests {
         ));
 
         let mut system_state: SystemState<(
-            Query<(&Name, &Children), With<Project>>,
-            Query<(&Level, &Name, &Children)>,
-            Query<(&Layer, &Name, &Transform, &Children)>,
-            Query<(&Element, &Name, &Transform)>,
+            Query<ProjectQuery>,
+            Query<LevelQuery>,
+            Query<LayerQuery>,
+            Query<ElementQuery>,
         )> = SystemState::new(&mut world);
         let (project_query, level_query, layer_query, object_query) = system_state.get(&world);
         let project = project_query.single()?;
 
-        let document = Document::new(project, level_query, layer_query, object_query);
+        let document = Document::new(&project, level_query, layer_query, object_query);
         assert_eq!(document.name, String::from("Example Project"));
         assert_eq!(document.levels.len(), 1);
         assert_eq!(document.levels[0].name, String::from("First Level"));

--- a/crates/io/src/load_project.rs
+++ b/crates/io/src/load_project.rs
@@ -34,7 +34,7 @@ pub fn handle_load_project_event(
         .with_context(|| format!("Failed to parse project file '{}'", event.input.display()))?;
 
     commands
-        .spawn(Project::new(project.name))
+        .spawn(Project::new(event.input.clone(), project.name))
         .with_children(|commands| {
             for level in project.levels {
                 commands

--- a/crates/io/src/save_project.rs
+++ b/crates/io/src/save_project.rs
@@ -1,11 +1,8 @@
 //! Contains the events for saving projects and their handling systems.
 use crate::document::Document;
 use anyhow::Context;
-use bevy::prelude::{
-    BevyError, Children, Entity, Event, EventReader, Name, Query, Transform, With,
-};
-use bevy::prelude::{Commands, default};
-use data::{Element, Layer, Level, Project};
+use bevy::prelude::{BevyError, Commands, Entity, Event, EventReader, Query, default};
+use data::{ElementQuery, LayerQuery, LevelQuery, ProjectQuery};
 use serialization::serialize_to;
 use std::{fs::File, path::PathBuf};
 use utils::{AsyncComponent, report_progress};
@@ -54,10 +51,10 @@ impl SaveProjectEvent {
 pub fn handle_save_project(
     mut commands: Commands,
     mut events: EventReader<SaveProjectEvent>,
-    project_query: Query<(&Name, &Children), With<Project>>,
-    level_query: Query<(&Level, &Name, &Children)>,
-    layer_query: Query<(&Layer, &Name, &Transform, &Children)>,
-    object_query: Query<(&Element, &Name, &Transform)>,
+    project_query: Query<ProjectQuery>,
+    level_query: Query<LevelQuery>,
+    layer_query: Query<LayerQuery>,
+    object_query: Query<ElementQuery>,
 ) -> Result<(), BevyError> {
     let Some(event) = events.read().next() else {
         return Ok(());
@@ -67,7 +64,7 @@ pub fn handle_save_project(
 
     let entity = event.project;
     let output = event.output.clone();
-    let document = Document::new(project, level_query, layer_query, object_query);
+    let document = Document::new(&project, level_query, layer_query, object_query);
     commands.spawn(AsyncComponent::new_io(
         async move |sender| {
             let file = File::create(output.clone()).with_context(|| {

--- a/crates/io/src/save_project.rs
+++ b/crates/io/src/save_project.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use bevy::prelude::{BevyError, Commands, Entity, Event, EventReader, Query, default};
 use data::{ElementQuery, LayerQuery, LevelQuery, ProjectQuery};
 use serialization::serialize_to;
-use std::{fs::File, path::PathBuf};
+use std::fs::File;
 use utils::{AsyncComponent, report_progress};
 
 /// When this event is sent, the associated `project` will be fetched and saved.
@@ -19,8 +19,6 @@ use utils::{AsyncComponent, report_progress};
 pub struct SaveProjectEvent {
     /// The [`Entity`] of the [`data::Project`] to save.
     pub(crate) project: Entity,
-    /// The output path of the savefile that will be created.
-    pub(crate) output: PathBuf,
 }
 
 /// This event indicates that the work of a [`SaveProjectEvent`] has completed.
@@ -28,19 +26,13 @@ pub struct SaveProjectEvent {
 pub struct SaveProjectCompleteEvent {
     /// The [`Entity`] of the [`data::Project`] that was saved.
     pub project: Entity,
-    /// The output path of the savefile that was created.
-    #[allow(
-        dead_code,
-        reason = "Temporarily until editor and status reporting is implemented"
-    )]
-    pub output: PathBuf, // TODO: remove dead_code
 }
 
 impl SaveProjectEvent {
     /// Generate a new [`SaveProjectEvent`] that can be dispatched.
     #[must_use = "This event does nothing unless you dispatch it"]
-    pub fn new(project: Entity, output: PathBuf) -> Self {
-        Self { project, output }
+    pub fn new(project: Entity) -> Self {
+        Self { project }
     }
 }
 
@@ -63,7 +55,7 @@ pub fn handle_save_project(
     let project = project_query.get(event.project)?;
 
     let entity = event.project;
-    let output = event.output.clone();
+    let output = project.project.file.clone();
     let document = Document::new(&project, level_query, layer_query, object_query);
     commands.spawn(AsyncComponent::new_io(
         async move |sender| {
@@ -73,13 +65,7 @@ pub fn handle_save_project(
             serialize_to(&document, &default(), file)?;
 
             // Report completion
-            report_progress(
-                &sender,
-                SaveProjectCompleteEvent {
-                    project: entity,
-                    output,
-                },
-            )?;
+            report_progress(&sender, SaveProjectCompleteEvent { project: entity })?;
             Ok(())
         },
         |_, _| {

--- a/crates/io/tests/save_project_event.rs
+++ b/crates/io/tests/save_project_event.rs
@@ -7,8 +7,8 @@ use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
 use data::{Layer, Level, Project};
 use io::*;
+use std::fs::read_to_string;
 use std::time::Duration;
-use std::{fs::read_to_string, path::PathBuf};
 use tempfile::tempdir;
 use utils::CorePlugin;
 
@@ -50,10 +50,13 @@ fn save_project_event() -> anyhow::Result<()> {
     // Holds output files for this test, we hold the variable since it's deleted on drop.
     let temp_dir = tempdir()?;
     let mut app = App::new();
+    let mut output = std::path::PathBuf::from(temp_dir.path());
+    output.push("save_project_event_test_output.json"); // set output filename
+
     app.add_plugins((MinimalPlugins, CorePlugin, IOPlugin));
     app.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs(1)));
     app.world_mut().spawn((
-        Project::new("Example Project"),
+        Project::new(output.clone(), "Example Project"),
         children![(
             Level::new("First Level"),
             children![(Layer::new("First Layer", Transform::IDENTITY), children![])]
@@ -64,13 +67,10 @@ fn save_project_event() -> anyhow::Result<()> {
         .query::<(&Project, Entity)>()
         .single(app.world())?;
 
-    let mut output = PathBuf::from(temp_dir.path());
-    output.push("save_project_event_test_output.json"); // set output filename
     // run the schedules once to process Setup and spawn
     app.update();
 
-    app.world_mut()
-        .send_event(SaveProjectEvent::new(project, output.clone()));
+    app.world_mut().send_event(SaveProjectEvent::new(project));
 
     process_async_components(&mut app);
 
@@ -88,17 +88,6 @@ fn save_project_event() -> anyhow::Result<()> {
         project,
         "The completed event should have been for the project"
     );
-    assert_eq!(
-        event.unwrap().output,
-        output,
-        "The completed event should have been for the  output"
-    );
-    // TODO: this fails to query the event.
-    // assert_eq!(
-    //     app.world_mut().resource::<Events<SaveProjectCompleteEvent>>().len(),
-    //     1,
-    //     "SaveProjectEvent should have been emitted"
-    // );
 
     let json = read_to_string(output.clone())
         .with_context(|| format!("Output file {} could not be opened", output.display()))?;


### PR DESCRIPTION
This PR handles 2 things:
- it embeds the input/output file path in the `Project` component itself rather than having to pass it along when saving/loading (because how else will the editor know where to save to later?)
- it refactors the `Document` data structures in the `io` crate to use the specialised query types introduced in #105

This is an enabler for #106 as well, as that branch will introduce the UI for creating / loading projects